### PR TITLE
Add session notifier for new project sessions. Closes #151

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
             mkdir SyncFlowDeploymentDev && cd SyncFlowDeploymentDev
             git clone git@github.com:oele-isis-vanderbilt/SyncFlow.git
             cd SyncFlow
-            git checkout -b 151-rmq-deployment-scheme
+            git checkout -b 151-rmq-deployment-scheme origin/151-rmq-deployment-scheme
             cp ~/rabbitmq-deployment/rabbitmq.dev.conf docker/rabbitmq/rabbitmq.dev.conf
             cp $HOME/.deployment_config_dev_cloud.json  deployment_config_dev_cloud.json
             chmod +x docker/generate-prod-config

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 151-rmq-deployment-scheme
 
   release: # Trigger the workflow on release events
     types: [published]
@@ -34,7 +33,6 @@ jobs:
             mkdir SyncFlowDeploymentDev && cd SyncFlowDeploymentDev
             git clone git@github.com:oele-isis-vanderbilt/SyncFlow.git
             cd SyncFlow
-            git checkout -b 151-rmq-deployment-scheme origin/151-rmq-deployment-scheme
             cp ~/rabbitmq-deployment/rabbitmq.dev.conf docker/rabbitmq/rabbitmq.dev.conf
             cp $HOME/.deployment_config_dev_cloud.json  deployment_config_dev_cloud.json
             chmod +x docker/generate-prod-config

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 151-rmq-deployment-scheme
 
   release: # Trigger the workflow on release events
     types: [published]
@@ -26,13 +27,15 @@ jobs:
           USERNAME: ${{ secrets.JETSTREAM2_USERNAME }}
         run: |
           echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
-          openssl rsa -in private_key -check
+          ssh-keygen -y -f private_key > /dev/null
           ssh -o StrictHostKeyChecking=no -i private_key ${USERNAME}@${HOST} '
             echo "Pulling latest changes from GitHub"
             rm -rf $HOME/SyncFlowDeploymentDev && cd $HOME
             mkdir SyncFlowDeploymentDev && cd SyncFlowDeploymentDev
             git clone git@github.com:oele-isis-vanderbilt/SyncFlow.git
             cd SyncFlow
+            git checkout -b 151-rmq-deployment-scheme
+            cp ~/rabbitmq-deployment/rabbitmq.dev.conf docker/rabbitmq/rabbitmq.dev.conf
             cp $HOME/.deployment_config_dev_cloud.json  deployment_config_dev_cloud.json
             chmod +x docker/generate-prod-config
             ./docker/generate-prod-config --config-file deployment_config_dev_cloud.json --outfile-name .env.dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
           USERNAME: ${{ secrets.JETSTREAM2_USERNAME }}
         run: |
           echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
-          openssl rsa -in private_key -check
+          ssh-keygen -y -f private_key > /dev/null
           ssh -o StrictHostKeyChecking=no -i private_key ${USERNAME}@${HOST} '
             echo "Pulling latest changes from GitHub"
             rm -rf $HOME/SyncFlowDeploymentProd && cd $HOME
@@ -77,7 +77,7 @@ jobs:
           USERNAME: ${{ secrets.JETSTREAM2_USERNAME }}
         run: |
           echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
-          openssl rsa -in private_key -check
+          ssh-keygen -y -f private_key > /dev/null
           ssh -o StrictHostKeyChecking=no -i private_key ${USERNAME}@${HOST} '
             sudo chmod 666 /var/run/docker.sock
             docker system prune -f

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -291,9 +291,14 @@ dependencies = [
  "amqp_serde",
  "async-trait",
  "bytes",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.6",
  "serde",
  "serde_bytes",
  "tokio",
+ "tokio-rustls 0.26.0",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -442,6 +447,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd82dba44d209fddb11c190e0a94b78651f95299598e472215667417a03ff1d"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +517,29 @@ dependencies = [
  "getrandom",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.72",
+ "which",
 ]
 
 [[package]]
@@ -604,6 +659,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +696,26 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -946,6 +1030,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1160,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1274,6 +1370,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1644,10 +1749,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "libwebrtc"
@@ -1819,6 +1940,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,6 +1979,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
 name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,6 +2005,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2495,6 +2638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +2683,8 @@ version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki 0.102.6",
@@ -2574,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
@@ -2594,6 +2745,7 @@ version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2782,6 +2934,12 @@ dependencies = [
  "serde",
  "utoipa",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3430,6 +3588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webrtc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3455,6 +3622,18 @@ dependencies = [
  "scratch",
  "semver",
  "zip",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -272,6 +272,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "amqp_serde"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "787581044ca08ad61cdb3a4e21afba087fb8cdba3bb3e23ce69a7d091808014d"
+dependencies = [
+ "bytes",
+ "serde",
+ "serde_bytes_ng",
+]
+
+[[package]]
+name = "amqprs"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e93684f1ae3c63429509ce3bf8a587bffc414f71a13810ed3e5f2c8757888b0"
+dependencies = [
+ "amqp_serde",
+ "async-trait",
+ "bytes",
+ "serde",
+ "serde_bytes",
+ "tokio",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +393,7 @@ name = "application"
 version = "0.1.0"
 dependencies = [
  "aes-gcm",
+ "amqprs",
  "base64 0.22.1",
  "bcrypt",
  "chrono",
@@ -390,6 +416,17 @@ dependencies = [
  "thiserror",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2653,6 +2690,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes_ng"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb0ebce8684e2253f964e8b6ce51f0ccc6666bbb448fb4a6788088bda6544b6"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/crates/api/src/bin/api.rs
+++ b/crates/api/src/bin/api.rs
@@ -58,7 +58,7 @@ async fn main() -> std::io::Result<()> {
 
     let session_service = SessionService::new(&config.encryption_key, pool.clone());
     let device_service = device_service::DeviceService::new(&config, pool.clone());
-    let rmq_auth_service = RMQAuthService::new(auth_service.clone(), config.clone());
+    let rmq_auth_service = RMQAuthService::new(auth_service.clone(), config.clone(), pool.clone());
     let session_notifier_service = SessionNotifier::create(config.rabbitmq_config.clone())
         .await
         .expect("Failed to create session notifier");

--- a/crates/api/src/bin/api.rs
+++ b/crates/api/src/bin/api.rs
@@ -63,6 +63,15 @@ async fn main() -> std::io::Result<()> {
         .await
         .expect("Failed to create session notifier");
 
+    let queue_name = session_notifier_service
+        .initialize()
+        .await
+        .unwrap_or_else(|e| {
+            panic!("Failed to initialize session notifier: {}", e);
+        });
+
+    info!("Session notifier initialized with queue: {:?}", queue_name);
+
     HttpServer::new(move || {
         let mut app = App::new()
             .wrap(auth_middleware::Authentication) // Comment this line if you want to integrate with yew-address-book-frontend

--- a/crates/api/src/bin/api.rs
+++ b/crates/api/src/bin/api.rs
@@ -1,12 +1,14 @@
 use actix_web::{web, App, HttpResponse, HttpServer};
 use api::apidoc::init_api_doc;
-use api::auth_middleware;
 use api::login_handlers::init_routes as login_init_routes;
 use api::oauth_handlers::init_github_oauth_routes;
 use api::project_handlers::init_routes as project_init_routes;
+use api::{auth_middleware, rmq_handlers};
 
 use application::project::devices::device_service;
 use application::project::session_service::SessionService;
+use application::rmq::auth::RMQAuthService;
+use application::rmq::session_notifier::SessionNotifier;
 use application::users::account_service::AccountService;
 
 use infrastructure::establish_connection_pool;
@@ -56,6 +58,10 @@ async fn main() -> std::io::Result<()> {
 
     let session_service = SessionService::new(&config.encryption_key, pool.clone());
     let device_service = device_service::DeviceService::new(&config, pool.clone());
+    let rmq_auth_service = RMQAuthService::new(auth_service.clone(), config.clone());
+    let session_notifier_service = SessionNotifier::create(config.rabbitmq_config.clone())
+        .await
+        .expect("Failed to create session notifier");
 
     HttpServer::new(move || {
         let mut app = App::new()
@@ -71,7 +77,11 @@ async fn main() -> std::io::Result<()> {
                     cfg,
                     web::Data::new(session_service.clone()),
                     web::Data::new(device_service.clone()),
+                    web::Data::new(session_notifier_service.clone()),
                 )
+            })
+            .configure(|cfg| {
+                rmq_handlers::init_routes(cfg, web::Data::new(rmq_auth_service.clone()))
             });
 
         if config.github_client_id.is_some() && config.github_client_secret.is_some() {

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -5,3 +5,4 @@ pub mod login_handlers;
 pub mod oauth_handlers;
 pub mod ownership_middleware;
 pub mod project_handlers;
+pub mod rmq_handlers;

--- a/crates/api/src/login_handlers.rs
+++ b/crates/api/src/login_handlers.rs
@@ -2,7 +2,7 @@ use crate::helpers::{error_response, json_ok_response};
 use actix_web::web::{Json, ReqData};
 use actix_web::{delete, get, post, web, HttpRequest, HttpResponse};
 use application::users::account_service::AccountService;
-use application::users::tokens_manager::UserInfo;
+use application::users::tokens_manager::TokenInfo;
 use shared::constants;
 use shared::response_models::Response;
 use shared::user_models::{ApiKeyRequest, LoginRequest, RefreshTokenRequest, SignUpRequest};
@@ -107,7 +107,7 @@ pub async fn refresh_login_token(
 #[post("/api-key")]
 pub async fn create_api_key(
     api_token_request: Json<ApiKeyRequest>,
-    user_data: ReqData<UserInfo>,
+    user_data: ReqData<TokenInfo>,
     user_auth: web::Data<AccountService>,
 ) -> HttpResponse {
     user_auth
@@ -123,7 +123,7 @@ pub async fn create_api_key(
 pub async fn delete_api_key(
     account_service: web::Data<AccountService>,
     key_id: web::Path<String>,
-    user_data: ReqData<UserInfo>,
+    user_data: ReqData<TokenInfo>,
 ) -> HttpResponse {
     account_service
         .delete_api_key(user_data.into_inner().user_id, &key_id)
@@ -141,7 +141,7 @@ pub async fn delete_api_key(
 )]
 #[get("/api-keys")]
 pub async fn list_all_api_keys(
-    user_data: ReqData<UserInfo>,
+    user_data: ReqData<TokenInfo>,
     user_auth: web::Data<AccountService>,
 ) -> HttpResponse {
     user_auth
@@ -160,7 +160,7 @@ pub async fn list_all_api_keys(
 )]
 #[get("/me")]
 pub async fn me(
-    user_data: ReqData<UserInfo>,
+    user_data: ReqData<TokenInfo>,
     user_auth: web::Data<AccountService>,
 ) -> HttpResponse {
     user_auth

--- a/crates/api/src/ownership_middleware.rs
+++ b/crates/api/src/ownership_middleware.rs
@@ -8,7 +8,7 @@ use actix_web::{
     Error, HttpMessage, HttpResponse,
 };
 use application::users::account_service::AccountService;
-use application::users::tokens_manager::UserInfo;
+use application::users::tokens_manager::TokenInfo;
 use futures_util::future::LocalBoxFuture;
 use shared::constants;
 use shared::response_models::Response;
@@ -70,7 +70,7 @@ where
                 .any(|ignore_route| req.path().starts_with(ignore_route))
         {
             OwnershipStatus::Ignored
-        } else if let Some(user_info) = req.extensions().get::<UserInfo>() {
+        } else if let Some(user_info) = req.extensions().get::<TokenInfo>() {
             let account_service = req.app_data::<Data<AccountService>>();
 
             account_service

--- a/crates/api/src/project_handlers.rs
+++ b/crates/api/src/project_handlers.rs
@@ -10,7 +10,7 @@ use actix_web::{
 use application::{
     project::{devices::device_service::DeviceService, session_service::SessionService},
     rmq::session_notifier::SessionNotifier,
-    users::{account_service::AccountService, tokens_manager::UserInfo},
+    users::{account_service::AccountService, tokens_manager::TokenInfo},
 };
 use shared::{
     device_models::DeviceRegisterRequest,
@@ -32,7 +32,7 @@ use shared::{
 )]
 #[get("/list")]
 async fn list_projects(
-    user_data: ReqData<UserInfo>,
+    user_data: ReqData<TokenInfo>,
     account_service: web::Data<AccountService>,
 ) -> HttpResponse {
     account_service
@@ -53,7 +53,7 @@ async fn list_projects(
 )]
 #[get("/summarize")]
 async fn summarize_projects(
-    user_data: ReqData<UserInfo>,
+    user_data: ReqData<TokenInfo>,
     account_service: web::Data<AccountService>,
 ) -> HttpResponse {
     account_service
@@ -78,7 +78,7 @@ async fn summarize_projects(
 )]
 #[get("/{project_id}")]
 async fn get_project(
-    user_data: ReqData<UserInfo>,
+    user_data: ReqData<TokenInfo>,
     project_id: web::Path<String>,
     account_service: web::Data<AccountService>,
 ) -> HttpResponse {
@@ -104,7 +104,7 @@ async fn get_project(
 )]
 #[delete("/{project_id}")]
 async fn delete_project(
-    user_data: ReqData<UserInfo>,
+    user_data: ReqData<TokenInfo>,
     project_id: web::Path<String>,
     account_service: web::Data<AccountService>,
 ) -> HttpResponse {
@@ -128,7 +128,7 @@ async fn delete_project(
 )]
 #[post("/create")]
 async fn create_project(
-    user_data: ReqData<UserInfo>,
+    user_data: ReqData<TokenInfo>,
     project_request: web::Json<ProjectRequest>,
     account_service: web::Data<AccountService>,
 ) -> HttpResponse {
@@ -192,7 +192,7 @@ async fn create_session(
     session_service
         .create_session(
             &project_id,
-            session.into_inner(),
+            &session.into_inner(),
             &notifier_service.into_inner(),
         )
         .await
@@ -305,7 +305,7 @@ async fn stop_session(
 #[post("/{project_id}/settings/create-api-key")]
 async fn create_api_key(
     project_id: web::Path<String>,
-    user_info: ReqData<UserInfo>,
+    user_info: ReqData<TokenInfo>,
     account_service: web::Data<AccountService>,
     request: web::Json<ApiKeyRequest>,
 ) -> HttpResponse {
@@ -319,7 +319,7 @@ async fn create_api_key(
 #[get("{project_id}/settings/api-keys")]
 async fn get_all_api_keys(
     project_id: web::Path<String>,
-    user_info: ReqData<UserInfo>,
+    user_info: ReqData<TokenInfo>,
     account_service: web::Data<AccountService>,
 ) -> HttpResponse {
     let user_id = user_info.into_inner().user_id;
@@ -332,7 +332,7 @@ async fn get_all_api_keys(
 #[delete("{project_id}/settings/api-keys/{api_key_id}")]
 async fn delete_api_key(
     path: web::Path<(String, i32)>,
-    user_info: ReqData<UserInfo>,
+    user_info: ReqData<TokenInfo>,
     account_service: web::Data<AccountService>,
 ) -> HttpResponse {
     let (project_id, api_key_id) = path.into_inner();
@@ -369,7 +369,7 @@ async fn get_device(
 #[post("{project_id}/devices/register")]
 async fn register_device(
     project_id: web::Path<String>,
-    user_info: ReqData<UserInfo>,
+    user_info: ReqData<TokenInfo>,
     request: web::Json<DeviceRegisterRequest>,
     device_service: web::Data<DeviceService>,
     notifier_service: web::Data<SessionNotifier>,

--- a/crates/api/src/rmq_handlers.rs
+++ b/crates/api/src/rmq_handlers.rs
@@ -1,0 +1,27 @@
+use actix_web::{get, web, HttpResponse};
+
+use application::rmq::auth::{RMQAuthQuery, RMQAuthService};
+
+#[get("/auth/user")]
+async fn authorize_user(
+    auth_query: web::Query<RMQAuthQuery>,
+    auth_service: web::Data<RMQAuthService>,
+) -> HttpResponse {
+    // HttpResponse::Ok().finish()
+    let is_user_valid = auth_service.authorize(&auth_query.into_inner());
+    if is_user_valid {
+        HttpResponse::Ok().body("allow administrator")
+    } else {
+        HttpResponse::Unauthorized().finish()
+    }
+}
+
+// #[get("/auth/")]
+
+pub fn init_routes(cfg: &mut web::ServiceConfig, auth_service: web::Data<RMQAuthService>) {
+    let rmq_scope = web::scope("/rmq")
+        .app_data(auth_service.clone())
+        .service(authorize_user);
+
+    cfg.service(rmq_scope);
+}

--- a/crates/api/src/rmq_handlers.rs
+++ b/crates/api/src/rmq_handlers.rs
@@ -1,13 +1,14 @@
 use actix_web::{get, web, HttpResponse};
 
-use application::rmq::auth::{RMQAuthQuery, RMQAuthService};
+use application::rmq::auth::{
+    RMQAuthQuery, RMQAuthResourcePathQuery, RMQAuthService, RMQAuthTopicQuery, RMQAuthVhostQuery,
+};
 
 #[get("/auth/user")]
 async fn authorize_user(
     auth_query: web::Query<RMQAuthQuery>,
     auth_service: web::Data<RMQAuthService>,
 ) -> HttpResponse {
-    // HttpResponse::Ok().finish()
     let is_user_valid = auth_service.authorize(&auth_query.into_inner());
     if is_user_valid {
         HttpResponse::Ok().body("allow administrator")
@@ -16,12 +17,52 @@ async fn authorize_user(
     }
 }
 
-// #[get("/auth/")]
+#[get("/auth/vhost")]
+async fn authorize_vhost(
+    vhost_query: web::Query<RMQAuthVhostQuery>,
+    auth_service: web::Data<RMQAuthService>,
+) -> HttpResponse {
+    let is_user_valid = auth_service.authorize_vhost(&vhost_query.into_inner());
+    if is_user_valid {
+        HttpResponse::Ok().body("allow")
+    } else {
+        HttpResponse::Unauthorized().finish()
+    }
+}
+
+#[get("/auth/resource")]
+async fn authorize_resource_path(
+    resource_path_query: web::Query<RMQAuthResourcePathQuery>,
+    auth_service: web::Data<RMQAuthService>,
+) -> HttpResponse {
+    let is_user_valid = auth_service.authorize_resource_path(&resource_path_query.into_inner());
+    if is_user_valid {
+        HttpResponse::Ok().body("allow")
+    } else {
+        HttpResponse::Unauthorized().finish()
+    }
+}
+
+#[get("/auth/topic")]
+async fn authorize_topic(
+    topic_query: web::Query<RMQAuthTopicQuery>,
+    auth_service: web::Data<RMQAuthService>,
+) -> HttpResponse {
+    let is_user_valid = auth_service.authorize_topic(&topic_query.into_inner());
+    if is_user_valid {
+        HttpResponse::Ok().body("allow")
+    } else {
+        HttpResponse::Unauthorized().finish()
+    }
+}
 
 pub fn init_routes(cfg: &mut web::ServiceConfig, auth_service: web::Data<RMQAuthService>) {
     let rmq_scope = web::scope("/rmq")
         .app_data(auth_service.clone())
-        .service(authorize_user);
+        .service(authorize_user)
+        .service(authorize_vhost)
+        .service(authorize_resource_path)
+        .service(authorize_topic);
 
     cfg.service(rmq_scope);
 }

--- a/crates/api/src/rmq_handlers.rs
+++ b/crates/api/src/rmq_handlers.rs
@@ -11,7 +11,7 @@ async fn authorize_user(
 ) -> HttpResponse {
     let is_user_valid = auth_service.authorize(&auth_query.into_inner());
     if is_user_valid {
-        HttpResponse::Ok().body("allow administrator")
+        HttpResponse::Ok().body("allow")
     } else {
         HttpResponse::Unauthorized().finish()
     }

--- a/crates/application/Cargo.toml
+++ b/crates/application/Cargo.toml
@@ -30,4 +30,4 @@ livekit-client = { package="livekit", version = "0.6.0", features = ["rustls-tls
 livekit-api = "0.4.0"
 livekit-protocol = "0.3.5"
 livekit-runtime = { version = "0.3.0", features = ["tokio"] }
-amqprs = "2.1.0"
+amqprs = { version = "2.1.0", features = ["tls"] }

--- a/crates/application/Cargo.toml
+++ b/crates/application/Cargo.toml
@@ -30,3 +30,4 @@ livekit-client = { package="livekit", version = "0.6.0", features = ["rustls-tls
 livekit-api = "0.4.0"
 livekit-protocol = "0.3.5"
 livekit-runtime = { version = "0.3.0", features = ["tokio"] }
+amqprs = "2.1.0"

--- a/crates/application/src/bin/session_notifier_test.rs
+++ b/crates/application/src/bin/session_notifier_test.rs
@@ -1,0 +1,28 @@
+use std::error::Error;
+
+use application::rmq::session_notifier::SessionNotifier;
+use shared::deployment_config::DeploymentConfig;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let config = DeploymentConfig::load();
+    let session_notifier = SessionNotifier::create(config.rabbitmq_config).await?;
+
+    let queue_name = session_notifier.initialize().await?;
+    println!("Queue name: {}", queue_name);
+
+    session_notifier
+        .bind_routing_key("project-1.group-2")
+        .await?;
+
+    for i in 0..10 {
+        let message = format!("Message {}", i);
+        session_notifier
+            .publish("project-1.group-2", message.as_bytes().to_vec())
+            .await?;
+        println!("Sent message: {}", message);
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    }
+
+    Ok(())
+}

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod livekit;
 pub mod project;
+pub mod rmq;
 pub mod users;

--- a/crates/application/src/project/devices/device_crud.rs
+++ b/crates/application/src/project/devices/device_crud.rs
@@ -123,3 +123,23 @@ pub fn delete_device(
 
     Ok(device)
 }
+
+pub fn get_possible_routing_keys(
+    proj_id: &str,
+    conn: &mut PgConnection,
+) -> Result<Vec<String>, DeviceError> {
+    use domain::schema::syncflow::project_devices::dsl::*;
+
+    let proj_uuid = Uuid::parse_str(proj_id)?;
+
+    let devices = project_devices
+        .filter(project_id.eq(proj_uuid))
+        .load::<ProjectDevice>(conn)?;
+
+    let routing_keys = devices
+        .iter()
+        .map(|d| format!("{}.{}", proj_id, d.device_group))
+        .collect();
+
+    Ok(routing_keys)
+}

--- a/crates/application/src/project/devices/device_crud.rs
+++ b/crates/application/src/project/devices/device_crud.rs
@@ -1,3 +1,4 @@
+use crate::rmq::session_notifier::SessionNotifierError;
 use diesel::{prelude::*, PgConnection};
 use domain::models::{NewProjectDevice, ProjectDevice};
 use shared::device_models::DeviceRegisterRequest;
@@ -14,6 +15,9 @@ pub enum DeviceError {
 
     #[error("Device not found")]
     NotFound(String),
+
+    #[error("Session Notifier Error: {0}")]
+    SessionNotifierError(#[from] SessionNotifierError),
 }
 
 impl From<DeviceError> for shared::response_models::Response {
@@ -36,6 +40,10 @@ impl From<DeviceError> for shared::response_models::Response {
             DeviceError::NotFound(e) => shared::response_models::Response {
                 status: 404,
                 message: e,
+            },
+            DeviceError::SessionNotifierError(e) => shared::response_models::Response {
+                status: 500,
+                message: e.to_string(),
             },
         }
     }

--- a/crates/application/src/project/devices/device_service.rs
+++ b/crates/application/src/project/devices/device_service.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
 
+use domain::models::ProjectDevice;
 use infrastructure::DbPool;
 use shared::deployment_config::DeploymentConfig;
 use shared::device_models::{DeviceRegisterRequest, DeviceResponse};
 
 use super::device_crud::{self, DeviceError};
+use crate::rmq::session_notifier::SessionNotifier;
 
 pub struct DeviceService {
     config: DeploymentConfig,
@@ -19,11 +21,12 @@ impl DeviceService {
         }
     }
 
-    pub fn register_device(
+    pub async fn register_device(
         &self,
         project_id: &str,
         user_id: i32,
         registration_request: &DeviceRegisterRequest,
+        notifier: &SessionNotifier,
     ) -> Result<DeviceResponse, DeviceError> {
         let device = device_crud::register_device(
             project_id,
@@ -31,12 +34,16 @@ impl DeviceService {
             registration_request,
             &mut self.pool.get().unwrap(),
         )?;
-        Ok(device.into())
+
+        let routing_key = self.routing_key_for(&device);
+        notifier.bind_routing_key(&routing_key).await?;
+
+        Ok(self.device_to_response(&device))
     }
 
     pub fn list_devices(&self, project_id: &str) -> Result<Vec<DeviceResponse>, DeviceError> {
         let devices = device_crud::list_devices(project_id, &mut self.pool.get().unwrap())?;
-        Ok(devices.into_iter().map(Into::into).collect())
+        Ok(devices.iter().map(|d| self.device_to_response(d)).collect())
     }
 
     pub fn get_device(
@@ -45,7 +52,7 @@ impl DeviceService {
         device_id: &str,
     ) -> Result<DeviceResponse, DeviceError> {
         let device = device_crud::get_device(project_id, device_id, &mut self.pool.get().unwrap())?;
-        Ok(device.into())
+        Ok(self.device_to_response(&device))
     }
 
     pub fn delete_device(
@@ -55,7 +62,17 @@ impl DeviceService {
     ) -> Result<DeviceResponse, DeviceError> {
         let device =
             device_crud::delete_device(project_id, device_id, &mut self.pool.get().unwrap())?;
-        Ok(device.into())
+        Ok(self.device_to_response(&device))
+    }
+
+    fn routing_key_for(&self, device: &ProjectDevice) -> String {
+        format!("{}.{}", device.project_id, device.device_group)
+    }
+
+    fn device_to_response(&self, device: &ProjectDevice) -> DeviceResponse {
+        let routing_key = self.routing_key_for(device);
+        let exchange_name = &self.config.rabbitmq_config.exchange_name;
+        device.into_device_response(&routing_key, exchange_name)
     }
 }
 

--- a/crates/application/src/project/project_crud.rs
+++ b/crates/application/src/project/project_crud.rs
@@ -5,8 +5,8 @@ use crate::{
 };
 use diesel::{prelude::*, PgConnection};
 use domain::models::{
-    NewProject, NewProjectAPIKey, Project, ProjectAPIKey, ProjectSession, ProjectSessionStatus,
-    StorageType,
+    NewProject, NewProjectAPIKey, Project, ProjectAPIKey, ProjectDevice, ProjectSession,
+    ProjectSessionStatus, StorageType,
 };
 use livekit_api::services::ServiceError;
 use shared::{
@@ -527,4 +527,24 @@ pub fn fetch_api_key_by_key(
         })?;
 
     Ok(key)
+}
+
+pub fn project_contains_device_group(
+    proj_id: &str,
+    device_group_name: &str,
+    conn: &mut PgConnection,
+) -> Result<Vec<ProjectDevice>, ProjectError> {
+    use domain::schema::syncflow::project_devices::dsl::*;
+
+    let project = get_project_by_id(proj_id, conn)?;
+
+    let devices = project_devices
+        .filter(
+            project_id
+                .eq(project.id)
+                .and(device_group.eq(device_group_name)),
+        )
+        .load::<ProjectDevice>(conn)?;
+
+    Ok(devices)
 }

--- a/crates/application/src/project/session_crud.rs
+++ b/crates/application/src/project/session_crud.rs
@@ -47,6 +47,9 @@ pub enum SessionError {
 
     #[error("Session Notifier Error: {0}")]
     SessionNotifierError(#[from] SessionNotifierError),
+
+    #[error("Invalid Device Group Error: {0}")]
+    InvalidDeviceGroupError(String),
 }
 
 #[derive(Debug, Clone)]
@@ -132,6 +135,10 @@ impl From<SessionError> for shared::response_models::Response {
             SessionError::SessionNotifierError(e) => shared::response_models::Response {
                 status: 500,
                 message: e.to_string(),
+            },
+            SessionError::InvalidDeviceGroupError(e) => shared::response_models::Response {
+                status: 400,
+                message: e,
             },
         }
     }

--- a/crates/application/src/project/session_crud.rs
+++ b/crates/application/src/project/session_crud.rs
@@ -17,6 +17,7 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use super::project_crud::ProjectError;
+use crate::rmq::session_notifier::SessionNotifierError;
 
 #[derive(Debug, Error)]
 pub enum SessionError {
@@ -43,6 +44,9 @@ pub enum SessionError {
 
     #[error("Inactive Session Error: {0}")]
     InactiveSessionError(String),
+
+    #[error("Session Notifier Error: {0}")]
+    SessionNotifierError(#[from] SessionNotifierError),
 }
 
 #[derive(Debug, Clone)]
@@ -124,6 +128,10 @@ impl From<SessionError> for shared::response_models::Response {
             SessionError::InactiveSessionError(e) => shared::response_models::Response {
                 status: 400,
                 message: e,
+            },
+            SessionError::SessionNotifierError(e) => shared::response_models::Response {
+                status: 500,
+                message: e.to_string(),
             },
         }
     }

--- a/crates/application/src/rmq/auth.rs
+++ b/crates/application/src/rmq/auth.rs
@@ -1,0 +1,45 @@
+use crate::users::account_service::AccountService;
+use shared::deployment_config::DeploymentConfig;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RMQAuthQuery {
+    pub username: String,
+    pub password: String,
+}
+
+pub struct RMQAuthService {
+    account_service: AccountService,
+    deployment_config: DeploymentConfig,
+}
+
+impl RMQAuthService {
+    pub fn new(account_service: AccountService, deployment_config: DeploymentConfig) -> Self {
+        Self {
+            account_service,
+            deployment_config,
+        }
+    }
+
+    pub fn authorize(&self, auth_query: &RMQAuthQuery) -> bool {
+        if auth_query.username == self.deployment_config.rabbitmq_config.root_username
+            && auth_query.password == self.deployment_config.rabbitmq_config.root_password
+        {
+            true
+        } else {
+            self.account_service
+                .verify_token(&auth_query.password)
+                .is_ok()
+        }
+    }
+}
+
+impl Clone for RMQAuthService {
+    fn clone(&self) -> Self {
+        Self {
+            account_service: self.account_service.clone(),
+            deployment_config: self.deployment_config.clone(),
+        }
+    }
+}

--- a/crates/application/src/rmq/auth.rs
+++ b/crates/application/src/rmq/auth.rs
@@ -1,5 +1,13 @@
-use crate::users::account_service::AccountService;
+use crate::{
+    project::{
+        devices::device_crud::get_possible_routing_keys,
+        project_crud::project_contains_device_group,
+    },
+    users::account_service::AccountService,
+};
+use infrastructure::DbPool;
 use shared::deployment_config::DeploymentConfig;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
@@ -9,29 +17,137 @@ pub struct RMQAuthQuery {
     pub password: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RMQAuthVhostQuery {
+    pub username: String,
+    pub vhost: String,
+    pub ip: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RMQAuthResourcePathQuery {
+    pub username: String,
+    pub vhost: String,
+    pub resource: String,
+    pub name: String,
+    pub permission: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RMQAuthTopicQuery {
+    pub username: String,
+    pub vhost: String,
+    pub resource: String,
+    pub name: String,
+    pub permission: String,
+    pub routing_key: String,
+}
+
 pub struct RMQAuthService {
     account_service: AccountService,
     deployment_config: DeploymentConfig,
+    pool: Arc<DbPool>,
 }
 
 impl RMQAuthService {
-    pub fn new(account_service: AccountService, deployment_config: DeploymentConfig) -> Self {
+    pub fn new(
+        account_service: AccountService,
+        deployment_config: DeploymentConfig,
+        pool: Arc<DbPool>,
+    ) -> Self {
         Self {
             account_service,
             deployment_config,
+            pool,
         }
     }
 
     pub fn authorize(&self, auth_query: &RMQAuthQuery) -> bool {
-        if auth_query.username == self.deployment_config.rabbitmq_config.root_username
-            && auth_query.password == self.deployment_config.rabbitmq_config.root_password
-        {
-            true
-        } else {
-            self.account_service
-                .verify_token(&auth_query.password)
-                .is_ok()
-        }
+        let token_info = self.account_service.verify_token(&auth_query.username);
+        token_info
+            .map(|token| {
+                let project_id = token.project_id;
+
+                if project_id.is_none() {
+                    false
+                } else {
+                    let project_id = project_id.unwrap();
+
+                    project_contains_device_group(
+                        &project_id,
+                        &auth_query.password,
+                        &mut self.pool.get().unwrap(),
+                    )
+                    .map(|_| true)
+                    .unwrap_or(false)
+                }
+            })
+            .unwrap_or(false)
+    }
+
+    pub fn authorize_vhost(&self, vhost_query: &RMQAuthVhostQuery) -> bool {
+        let token_info = self.account_service.verify_token(&vhost_query.username);
+        token_info
+            .map(|_| vhost_query.vhost == "/")
+            .unwrap_or(false)
+    }
+
+    pub fn authorize_resource_path(&self, resource_path_query: &RMQAuthResourcePathQuery) -> bool {
+        let token_info = self
+            .account_service
+            .verify_token(&resource_path_query.username);
+        token_info
+            .map(|token| {
+                let project_id = token.project_id;
+                if project_id.is_none() {
+                    return false;
+                }
+                if resource_path_query.resource == "exchange"
+                    && resource_path_query.name
+                        == self.deployment_config.rabbitmq_config.exchange_name
+                    && resource_path_query.permission == "read"
+                {
+                    return true;
+                }
+
+                if resource_path_query.resource == "queue"
+                    && resource_path_query.name.starts_with("amq")
+                    && resource_path_query.permission == "write"
+                {
+                    return true;
+                }
+
+                true
+            })
+            .unwrap_or(false)
+    }
+
+    pub fn authorize_topic(&self, topic_query: &RMQAuthTopicQuery) -> bool {
+        let token_info = self.account_service.verify_token(&topic_query.username);
+
+        token_info
+            .map(|token| {
+                let project_id = token.project_id;
+                if project_id.is_none() {
+                    return false;
+                }
+                if topic_query.resource == "topic"
+                    && topic_query.name == self.deployment_config.rabbitmq_config.exchange_name
+                    && topic_query.permission == "read"
+                {
+                    let project_id = project_id.unwrap();
+                    let all_routing_keys_result =
+                        get_possible_routing_keys(&project_id, &mut self.pool.get().unwrap());
+
+                    let access = all_routing_keys_result
+                        .map(|routing_keys| routing_keys.contains(&topic_query.routing_key))
+                        .unwrap_or(false);
+
+                    return access;
+                }
+                true
+            })
+            .unwrap_or(false)
     }
 }
 
@@ -40,6 +156,7 @@ impl Clone for RMQAuthService {
         Self {
             account_service: self.account_service.clone(),
             deployment_config: self.deployment_config.clone(),
+            pool: self.pool.clone(),
         }
     }
 }

--- a/crates/application/src/rmq/auth.rs
+++ b/crates/application/src/rmq/auth.rs
@@ -88,11 +88,15 @@ impl RMQAuthService {
     pub fn authorize_vhost(&self, vhost_query: &RMQAuthVhostQuery) -> bool {
         let token_info = self.account_service.verify_token(&vhost_query.username);
         token_info
-            .map(|_| vhost_query.vhost == "/")
+            .map(|_| vhost_query.vhost == self.deployment_config.rabbitmq_config.vhost_name)
             .unwrap_or(false)
     }
 
     pub fn authorize_resource_path(&self, resource_path_query: &RMQAuthResourcePathQuery) -> bool {
+        if resource_path_query.vhost != self.deployment_config.rabbitmq_config.vhost_name {
+            return false;
+        }
+
         let token_info = self
             .account_service
             .verify_token(&resource_path_query.username);
@@ -123,6 +127,10 @@ impl RMQAuthService {
     }
 
     pub fn authorize_topic(&self, topic_query: &RMQAuthTopicQuery) -> bool {
+        if topic_query.vhost != self.deployment_config.rabbitmq_config.vhost_name {
+            return false;
+        }
+
         let token_info = self.account_service.verify_token(&topic_query.username);
 
         token_info

--- a/crates/application/src/rmq/mod.rs
+++ b/crates/application/src/rmq/mod.rs
@@ -1,0 +1,2 @@
+pub mod auth;
+pub mod session_notifier;

--- a/crates/application/src/rmq/session_notifier.rs
+++ b/crates/application/src/rmq/session_notifier.rs
@@ -1,0 +1,104 @@
+use amqprs::BasicProperties;
+use shared::deployment_config::RabbitMQConfig;
+
+use amqprs::channel::{
+    BasicPublishArguments, Channel, ExchangeDeclareArguments, QueueBindArguments,
+    QueueDeclareArguments,
+};
+use amqprs::connection::{Connection, OpenConnectionArguments};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SessionNotifierError {
+    #[error("Failed to connect to RabbitMQ: {0}")]
+    ConnectionError(#[from] amqprs::error::Error),
+
+    #[error("Failed to declare queue: {0}")]
+    QueueDeclareError(String),
+}
+
+pub struct SessionNotifier {
+    rabbitmq_config: RabbitMQConfig,
+    connection: Connection,
+    channel: Channel,
+}
+
+impl SessionNotifier {
+    pub async fn create(rabbitmq_config: RabbitMQConfig) -> Result<Self, SessionNotifierError> {
+        let connection = Connection::open(&OpenConnectionArguments::new(
+            &rabbitmq_config.host,
+            rabbitmq_config.port,
+            &rabbitmq_config.root_username,
+            &rabbitmq_config.root_password,
+        ))
+        .await?;
+        let channel = connection.open_channel(None).await?;
+
+        Ok(Self {
+            rabbitmq_config,
+            connection,
+            channel,
+        })
+    }
+
+    pub async fn bind_routing_key(&self, routing_key: &str) -> Result<(), SessionNotifierError> {
+        let exchange_name = &self.rabbitmq_config.exchange_name;
+        let queue_name = &self.rabbitmq_config.queue_name;
+
+        self.channel
+            .queue_bind(QueueBindArguments::new(
+                queue_name,
+                exchange_name,
+                routing_key,
+            ))
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn publish(
+        &self,
+        routing_key: &str,
+        message: Vec<u8>,
+    ) -> Result<(), SessionNotifierError> {
+        let exchange_name = &self.rabbitmq_config.exchange_name;
+
+        let args = BasicPublishArguments::new(exchange_name, routing_key);
+
+        self.channel
+            .basic_publish(BasicProperties::default(), message, args)
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn initialize(&self) -> Result<String, SessionNotifierError> {
+        let exchange_name = &self.rabbitmq_config.exchange_name;
+        let queue_name = &self.rabbitmq_config.queue_name;
+
+        let queue_declare_result = self
+            .channel
+            .queue_declare(QueueDeclareArguments::durable_client_named(queue_name))
+            .await?;
+
+        let queue_details = queue_declare_result.ok_or(SessionNotifierError::QueueDeclareError(
+            format!("Failed to declare queue: {}", queue_name),
+        ))?;
+
+        self.channel
+            .exchange_declare(ExchangeDeclareArguments::new(exchange_name, "topic"))
+            .await?;
+
+        Ok(queue_details.0)
+    }
+}
+
+impl Clone for SessionNotifier {
+    fn clone(&self) -> Self {
+        Self {
+            rabbitmq_config: self.rabbitmq_config.clone(),
+            connection: self.connection.clone(),
+            channel: self.channel.clone(),
+        }
+    }
+}

--- a/crates/application/src/users/account_service.rs
+++ b/crates/application/src/users/account_service.rs
@@ -1,7 +1,7 @@
 use super::{secret, tokens_manager, user};
 use crate::project::{self, project_crud};
 use crate::users::oauth::github::{fetch_github_user, verify_user_token, GithubUser};
-use crate::users::tokens_manager::{TokenTypes, UserInfo};
+use crate::users::tokens_manager::{TokenInfo, TokenTypes};
 use crate::users::user::UserError;
 use domain::models::User;
 use infrastructure::DbPool;
@@ -99,7 +99,7 @@ impl AccountService {
         self.tokens_manager.decode_token_unsafe(&token)
     }
 
-    pub fn verify_token(&self, token_data: &str) -> Result<UserInfo, UserError> {
+    pub fn verify_token(&self, token_data: &str) -> Result<TokenInfo, UserError> {
         self.tokens_manager
             .verify_token(token_data, &mut self.pool.get().unwrap())
     }

--- a/crates/application/src/users/tokens_manager.rs
+++ b/crates/application/src/users/tokens_manager.rs
@@ -11,10 +11,11 @@ pub type UserTokenType = TokenTypes;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct UserInfo {
+pub struct TokenInfo {
     pub user_id: i32,
     pub user_name: String,
     pub login_session: Option<String>,
+    pub project_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -173,7 +174,7 @@ impl JWTTokensManager {
         &self,
         token: &str,
         conn: &mut PgConnection,
-    ) -> Result<UserInfo, UserError> {
+    ) -> Result<TokenInfo, UserError> {
         let parsed_token = self.decode_token_unsafe(token)?;
         match parsed_token {
             TokenTypes::LoginToken(token_data) => {
@@ -193,10 +194,11 @@ impl JWTTokensManager {
                     return Err(UserError::TokenError("Invalid token".to_string()));
                 }
 
-                Ok(UserInfo {
+                Ok(TokenInfo {
                     user_id: token_data.user_id,
                     user_name: token_data.user_name.to_owned(),
                     login_session: Some(token_data.login_session.to_owned()),
+                    project_id: None,
                 })
             }
 
@@ -218,10 +220,11 @@ impl JWTTokensManager {
 
                 let user = user::get_user(api_key.user_id, conn)?;
 
-                Ok(UserInfo {
+                Ok(TokenInfo {
                     user_id: user.id,
                     user_name: user.username.to_owned(),
                     login_session: Some(token_data.login_session.to_owned()),
+                    project_id: None,
                 })
             }
 
@@ -243,10 +246,11 @@ impl JWTTokensManager {
                 }
 
                 let user = user::get_user(api_key.user_id, conn)?;
-                Ok(UserInfo {
+                Ok(TokenInfo {
                     user_id: user.id,
                     user_name: user.username.to_owned(),
                     login_session: None,
+                    project_id: None,
                 })
             }
 
@@ -274,10 +278,11 @@ impl JWTTokensManager {
                 }
 
                 let user = user::get_user(api_key.user_id, conn)?;
-                Ok(UserInfo {
+                Ok(TokenInfo {
                     user_id: user.id,
                     user_name: user.username.to_owned(),
                     login_session: None,
+                    project_id: Some(token_data.project_id.to_owned()),
                 })
             }
         }

--- a/crates/domain/src/models.rs
+++ b/crates/domain/src/models.rs
@@ -348,6 +348,22 @@ pub struct ProjectDevice {
     pub registered_by: i32,
 }
 
+impl ProjectDevice {
+    pub fn into_device_response(&self, routing_key: &str, exchange_name: &str) -> DeviceResponse {
+        DeviceResponse {
+            id: self.id.to_string(),
+            group: self.device_group.clone(),
+            comments: self.comments.clone(),
+            name: self.device_name.clone(),
+            registered_at: self.registered_at.and_utc().timestamp() as usize,
+            registered_by: self.registered_by,
+            project_id: self.project_id.to_string(),
+            session_notification_exchange_name: Some(exchange_name.to_string()),
+            session_notification_binding_key: Some(routing_key.to_string()),
+        }
+    }
+}
+
 impl From<ProjectDevice> for DeviceResponse {
     fn from(value: ProjectDevice) -> Self {
         DeviceResponse {
@@ -358,6 +374,8 @@ impl From<ProjectDevice> for DeviceResponse {
             registered_at: value.registered_at.and_utc().timestamp() as usize,
             registered_by: value.registered_by,
             project_id: value.project_id.to_string(),
+            session_notification_exchange_name: None,
+            session_notification_binding_key: None,
         }
     }
 }

--- a/crates/shared/src/constants.rs
+++ b/crates/shared/src/constants.rs
@@ -1,6 +1,6 @@
 pub const AUTHORIZATION_HEADER: &str = "Authorization";
 
-pub const IGNORE_ROUTES: [&str; 8] = [
+pub const IGNORE_ROUTES: [&str; 9] = [
     "/users/login",
     "/users/signup",
     "/users/refresh-token",
@@ -9,6 +9,7 @@ pub const IGNORE_ROUTES: [&str; 8] = [
     "/redoc",
     "/swagger-ui",
     "/api-docs",
+    "/rmq/auth/user",
 ];
 
 pub const IGNORE_PROJECT_OWNERSHIP_ROUTES: [&str; 3] =

--- a/crates/shared/src/constants.rs
+++ b/crates/shared/src/constants.rs
@@ -1,6 +1,6 @@
 pub const AUTHORIZATION_HEADER: &str = "Authorization";
 
-pub const IGNORE_ROUTES: [&str; 9] = [
+pub const IGNORE_ROUTES: [&str; 12] = [
     "/users/login",
     "/users/signup",
     "/users/refresh-token",
@@ -10,6 +10,9 @@ pub const IGNORE_ROUTES: [&str; 9] = [
     "/swagger-ui",
     "/api-docs",
     "/rmq/auth/user",
+    "/rmq/auth/vhost",
+    "/rmq/auth/resource",
+    "/rmq/auth/topic",
 ];
 
 pub const IGNORE_PROJECT_OWNERSHIP_ROUTES: [&str; 3] =

--- a/crates/shared/src/deployment_config.rs
+++ b/crates/shared/src/deployment_config.rs
@@ -63,6 +63,8 @@ pub struct RabbitMQConfig {
     pub root_password: String,
     pub exchange_name: String,
     pub queue_name: String,
+    pub use_ssl: bool,
+    pub vhost_name: String,
 }
 
 impl DeploymentConfig {

--- a/crates/shared/src/deployment_config.rs
+++ b/crates/shared/src/deployment_config.rs
@@ -20,6 +20,8 @@ pub struct DeploymentConfig {
 
     pub root_user: Option<RootUser>,
 
+    pub rabbitmq_config: RabbitMQConfig,
+
     /// Test configuration
     pub login_token: Option<String>,
     pub test_user: Option<String>,
@@ -51,6 +53,16 @@ pub struct S3Config {
 #[derive(Deserialize, Debug, Clone)]
 pub struct LocalConfig {
     pub recording_root_path: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct RabbitMQConfig {
+    pub host: String,
+    pub port: u16,
+    pub root_username: String,
+    pub root_password: String,
+    pub exchange_name: String,
+    pub queue_name: String,
 }
 
 impl DeploymentConfig {

--- a/crates/shared/src/device_models.rs
+++ b/crates/shared/src/device_models.rs
@@ -18,4 +18,13 @@ pub struct DeviceResponse {
     pub registered_at: usize,
     pub registered_by: i32,
     pub project_id: String,
+    pub session_notification_exchange_name: Option<String>,
+    pub session_notification_binding_key: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewSessionMessage {
+    pub session_id: String,
+    pub session_name: String,
 }

--- a/crates/shared/src/project_models.rs
+++ b/crates/shared/src/project_models.rs
@@ -13,6 +13,7 @@ pub struct NewSessionRequest {
     pub empty_timeout: Option<i32>,
     pub max_participants: Option<i32>,
     pub auto_recording: Option<bool>,
+    pub device_groups: Option<Vec<String>>,
 }
 
 impl NewSessionRequest {
@@ -38,6 +39,7 @@ impl Default for NewSessionRequest {
             empty_timeout: Some(600),
             max_participants: Some(100),
             auto_recording: Some(false),
+            device_groups: None,
         }
     }
 }

--- a/dashboard/app/dashboard/projects/[project_id]/page.tsx
+++ b/dashboard/app/dashboard/projects/[project_id]/page.tsx
@@ -33,6 +33,10 @@ export default async function Project({
     await (
       await projectClient.getProject(id)
     ).mapAsync(async (project) => {
+      const projectDevices = (
+        await projectClient.listDevices(project.id)
+      ).unwrapOr([]);
+
       return (
         <div className="flex flex-col p-2 dark:text-white">
           <ProjectHeader projectName={project.name} projectId={project.id} />
@@ -50,7 +54,7 @@ export default async function Project({
                 Sessions
               </h1>
             </div>
-            <CreateSession project={project} />
+            <CreateSession project={project} devices={projectDevices} />
             <Link
               href={`/dashboard/projects/${project.id}/sessions`}
               className="ml-2"

--- a/dashboard/app/dashboard/projects/[project_id]/sessions/page.tsx
+++ b/dashboard/app/dashboard/projects/[project_id]/sessions/page.tsx
@@ -26,6 +26,7 @@ export default async function Project({
   };
 
   const sessionResult = await projectClient.getSessions(id);
+  let projectDevices = (await projectClient.listDevices(id)).unwrapOr([]);
 
   return (
     await (
@@ -42,7 +43,7 @@ export default async function Project({
                 Active Sessions
               </h1>
             </div>
-            <CreateSession project={project} />
+            <CreateSession project={project} devices={projectDevices} />
           </div>
           <div className="min-h-20">
             {(

--- a/dashboard/app/lib/project-actions.ts
+++ b/dashboard/app/lib/project-actions.ts
@@ -114,7 +114,7 @@ export async function createProjectSession(
           success: false,
           data: null as any,
           errors: [
-            `An error occurred while creating the session. ${error.message} | Code: ${error.code}`,
+            `An error occurred while creating the session. ${JSON.stringify(error.message)} | Code: ${error.code}`,
           ],
         };
       });

--- a/dashboard/app/lib/project-client.ts
+++ b/dashboard/app/lib/project-client.ts
@@ -56,7 +56,11 @@ export const NewSessionSchema = z.object({
     .optional()
     .default('off')
     .transform((v) => v === 'on'),
-  deviceGroups: z.array(z.string()).optional().default([]),
+  deviceGroups: z
+    .string()
+    .optional()
+    .default('')
+    .transform((s) => s.split(',').map((s) => s.trim())),
 });
 
 export const NewApiKeySchema = z.object({

--- a/dashboard/app/lib/project-client.ts
+++ b/dashboard/app/lib/project-client.ts
@@ -56,6 +56,7 @@ export const NewSessionSchema = z.object({
     .optional()
     .default('off')
     .transform((v) => v === 'on'),
+  deviceGroups: z.array(z.string()).optional().default([]),
 });
 
 export const NewApiKeySchema = z.object({

--- a/dashboard/app/ui/dashboard/project/create-session.tsx
+++ b/dashboard/app/ui/dashboard/project/create-session.tsx
@@ -86,11 +86,9 @@ function CreateSessionModal({
 
   const submitWithGroups = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const form = e.currentTarget as HTMLFormElement;
-    let formData = new FormData(form);
-    selectedGroups.forEach((group, index) => {
-      formData.append(`deviceGroups${index}`, group);
-    });
+    let formData = new FormData(e.currentTarget);
+    formData.append('deviceGroups', selectedGroups.join(','));
+
     dispatch(formData);
   };
 

--- a/dashboard/app/ui/dashboard/utils.ts
+++ b/dashboard/app/ui/dashboard/utils.ts
@@ -18,3 +18,17 @@ export function partitionArray(arr: any[], size: number) {
     return acc;
   }, []);
 }
+
+export function groupBy<T extends Record<string, any>>(
+  arr: T[],
+  key: keyof T,
+): Record<string, T[]> {
+  return arr.reduce(
+    (acc, item) => {
+      const groupKey = String(item[key]);
+      (acc[groupKey] = acc[groupKey] || []).push(item);
+      return acc;
+    },
+    {} as Record<string, T[]>,
+  );
+}

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -28,6 +28,16 @@ services:
     depends_on:
       - postgres-syncflow-dev-prod
 
+  rabbitmq-dev-prod:
+    image: rabbitmq:4-management
+    container_name: rabbitmq-syncflow-dev-prod
+    ports:
+      - "20001:20001"
+      - "20002:20002"
+    volumes:
+      - rabbitmq-data-dev-prod:/var/lib/rabbitmq
+      - ./rabbitmq/rabbitmq.dev.conf:/etc/rabbitmq/rabbitmq.conf
+
   api-syncflow-dev-prod:
     build:
       context: ../crates
@@ -57,3 +67,4 @@ services:
 
 volumes:
   postgres-data-dev-prod:
+  rabbitmq-data-dev-prod:

--- a/docker/docker-compose.rmq.yaml
+++ b/docker/docker-compose.rmq.yaml
@@ -1,0 +1,14 @@
+services:
+  rabbit-mq-broker:
+    image: rabbitmq:4-management
+    container_name: demo-broker
+    volumes:
+      - rabbit-mq-data:/var/lib/rabbitmq
+      - ./rabbitmq.local.conf:/etc/rabbitmq/rabbitmq.conf
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    network_mode: "host"
+
+volumes:
+  rabbit-mq-data:

--- a/docker/docker-compose.rmq.yaml
+++ b/docker/docker-compose.rmq.yaml
@@ -4,11 +4,13 @@ services:
     container_name: demo-broker
     volumes:
       - rabbit-mq-data:/var/lib/rabbitmq
-      - ./rabbitmq.local.conf:/etc/rabbitmq/rabbitmq.conf
+      - ./rabbitmq/rabbitmq.local.conf:/etc/rabbitmq/rabbitmq.conf
     ports:
       - "5672:5672"
       - "15672:15672"
     network_mode: "host"
+    env_file:
+      - ../crates/.env
 
 volumes:
   rabbit-mq-data:

--- a/docker/generate-prod-config
+++ b/docker/generate-prod-config
@@ -101,6 +101,8 @@ class RabbitMQConfig(Config):
     port: int
     use_ssl: bool
     virtual_host_name: str
+    queue_name: str
+    exchange_name: str
 
     @classmethod
     def from_json(cls, json_dict: Dict[str, Any]) -> "RabbitMQConfig":
@@ -110,7 +112,9 @@ class RabbitMQConfig(Config):
             host=json_dict["host"],
             port=json_dict["port"],
             use_ssl=json_dict["use_ssl"],
-            virtual_host_name=json_dict["virtual_host_name"],
+            virtual_host_name=json_dict["vhost_name"],
+            queue_name=json_dict["queue_name"],
+            exchange_name=json_dict["exchange_name"],
         )
 
 

--- a/docker/generate-prod-config
+++ b/docker/generate-prod-config
@@ -100,7 +100,7 @@ class RabbitMQConfig(Config):
     host: str
     port: int
     use_ssl: bool
-    virtual_host_name: str
+    vhost_name: str
     queue_name: str
     exchange_name: str
 
@@ -112,7 +112,7 @@ class RabbitMQConfig(Config):
             host=json_dict["host"],
             port=json_dict["port"],
             use_ssl=json_dict["use_ssl"],
-            virtual_host_name=json_dict["vhost_name"],
+            vhost_name=json_dict["vhost_name"],
             queue_name=json_dict["queue_name"],
             exchange_name=json_dict["exchange_name"],
         )

--- a/docker/generate-prod-config
+++ b/docker/generate-prod-config
@@ -17,6 +17,8 @@ class Config:
     def as_env(self, prefix: str = "") -> str:
         env = []
         for field, value in asdict(self).items():
+            if isinstance(value, bool):
+                value = str(value).lower()
             env.append(f'{prefix.upper()}{field.upper()}="{value}"')
         return "\n".join(env)
 
@@ -90,6 +92,7 @@ class RootUser(Config):
             password=json_dict["password"],
         )
 
+
 @dataclass
 class RabbitMQConfig(Config):
     root_username: str
@@ -155,7 +158,6 @@ class ServiceConfig(Config):
             login_token=json_dict.get("login_token"),
             test_user=json_dict.get("test_user"),
             test_password=json_dict.get("test_password"),
-
         )
 
     def as_env(self, prefix: str = "") -> str:
@@ -168,7 +170,11 @@ class ServiceConfig(Config):
                 env.append(root_user_env)
             elif field == "rabbitmq_config" and value is not None:
                 rabbitmq_env = self.rabbitmq_config.as_env(
-                    prefix=f"{prefix.upper()}_RABBITMQ_CONFIG__" if prefix else "RABBITMQ_CONFIG__"
+                    prefix=(
+                        f"{prefix.upper()}_RABBITMQ_CONFIG__"
+                        if prefix
+                        else "RABBITMQ_CONFIG__"
+                    )
                 )
                 env.append(rabbitmq_env)
             elif value is not None:

--- a/docker/generate-prod-config
+++ b/docker/generate-prod-config
@@ -90,6 +90,22 @@ class RootUser(Config):
             password=json_dict["password"],
         )
 
+@dataclass
+class RabbitMQConfig(Config):
+    root_username: str
+    root_password: str
+    host: str
+    port: int
+
+    @classmethod
+    def from_json(cls, json_dict: Dict[str, Any]) -> "RabbitMQConfig":
+        return RabbitMQConfig(
+            root_username=json_dict["root_username"],
+            root_password=json_dict["root_password"],
+            host=json_dict["host"],
+            port=json_dict["port"],
+        )
+
 
 @dataclass
 class ServiceConfig(Config):
@@ -101,6 +117,7 @@ class ServiceConfig(Config):
     encryption_key: str
     jwt_expiration: int
     jwt_refresh_expiration: int
+    rabbitmq_config: RabbitMQConfig
     github_client_id: Optional[str] = None
     github_client_secret: Optional[str] = None
     root_user: Optional[RootUser] = None
@@ -116,6 +133,8 @@ class ServiceConfig(Config):
         else:
             root_user = None
 
+        rabbitmq_config = RabbitMQConfig.from_json(json_dict["rabbitmq_config"])
+
         return cls(
             app_host=json_dict["app_host"],
             app_port=json_dict["app_port"],
@@ -125,12 +144,14 @@ class ServiceConfig(Config):
             encryption_key=json_dict["encryption_key"],
             jwt_expiration=json_dict["jwt_expiration"],
             jwt_refresh_expiration=json_dict["jwt_refresh_expiration"],
+            rabbitmq_config=rabbitmq_config,
             github_client_id=json_dict.get("github_client_id"),
             github_client_secret=json_dict.get("github_client_secret"),
             root_user=root_user,
             login_token=json_dict.get("login_token"),
             test_user=json_dict.get("test_user"),
             test_password=json_dict.get("test_password"),
+
         )
 
     def as_env(self, prefix: str = "") -> str:
@@ -141,6 +162,11 @@ class ServiceConfig(Config):
                     prefix=f"{prefix.upper()}_ROOT_USER__" if prefix else "ROOT_USER__"
                 )
                 env.append(root_user_env)
+            elif field == "rabbitmq_config" and value is not None:
+                rabbitmq_env = self.rabbitmq_config.as_env(
+                    prefix=f"{prefix.upper()}_RABBITMQ_CONFIG__" if prefix else "RABBITMQ_CONFIG__"
+                )
+                env.append(rabbitmq_env)
             elif value is not None:
                 env.append(f'{prefix.upper()}{field.upper()}="{value}"')
         return "\n".join(env)

--- a/docker/generate-prod-config
+++ b/docker/generate-prod-config
@@ -96,6 +96,8 @@ class RabbitMQConfig(Config):
     root_password: str
     host: str
     port: int
+    use_ssl: bool
+    virtual_host_name: str
 
     @classmethod
     def from_json(cls, json_dict: Dict[str, Any]) -> "RabbitMQConfig":
@@ -104,6 +106,8 @@ class RabbitMQConfig(Config):
             root_password=json_dict["root_password"],
             host=json_dict["host"],
             port=json_dict["port"],
+            use_ssl=json_dict["use_ssl"],
+            virtual_host_name=json_dict["virtual_host_name"],
         )
 
 

--- a/docker/rabbitmq.local.conf
+++ b/docker/rabbitmq.local.conf
@@ -1,6 +1,15 @@
 default_user = syncflow
-default_pass = syncflow-admin
+default_pass = syncflow
 
 listeners.tcp.default = 5672
 
 management.tcp.port = 15672
+
+auth_backends.1 = internal
+auth_backends.2 = http
+
+auth_http.http_method   = get
+auth_http.user_path     = http://localhost:8081/rmq/auth/user
+auth_http.vhost_path    = http://localhost:8081/rmq/auth/vhost
+auth_http.resource_path = http://localhost:8081/rmq/auth/resource
+auth_http.topic_path    = http://localhost:8081/rmq/auth/topic

--- a/docker/rabbitmq.local.conf
+++ b/docker/rabbitmq.local.conf
@@ -1,0 +1,6 @@
+default_user = syncflow
+default_pass = syncflow-admin
+
+listeners.tcp.default = 5672
+
+management.tcp.port = 15672

--- a/docker/rabbitmq/rabbitmq.local.conf
+++ b/docker/rabbitmq/rabbitmq.local.conf
@@ -1,5 +1,6 @@
 default_user = syncflow
 default_pass = syncflow
+default_vhost = syncflow
 
 listeners.tcp.default = 5672
 


### PR DESCRIPTION
Uses a RabbitMQ's topical exchange with a single queue to notified subscribed devices on new project sessions.

## Checklist
- [x] Queue/Exchange Declare
- [x] Modify requests to incorporate groups on session addition
- [x] Send Join messages on session creation
- [x] RabbitMQ http backend for token verification
- [x] SSL Certificates for secured RMQ deployment
- [x] Automated Deployment Scheme for RabbitMQ.
- [x] Example New Session Publisher
